### PR TITLE
Fix: Limpando tabela protocolo_idx no script de limpeza mysql

### DIFF
--- a/mysql/v5.0.0/utilitarios/sei_script_limpeza_mysql.sql
+++ b/mysql/v5.0.0/utilitarios/sei_script_limpeza_mysql.sql
@@ -174,6 +174,7 @@ truncate table procedimento;
 
 truncate table protocolo;
 truncate table seq_protocolo;
+truncate table protocolo_idx;
 
 truncate table protocolo_federacao;
 


### PR DESCRIPTION
Ao executar o script de limpeza (MySQL) do SEI v 5.0.0, observei que os dados da tabela "protocolo_idx" não foram limpos.
Isso causou erro de Primary key duplicada ao tentar criar novos processos.

"Duplicate entry for key for protocolo_idx PRIMARY."

Para limpar a tabela em questão, adicionei:
- truncate table protocolo_idx;


Paulo Henrique Lima - Analista Judiciário - TJBA
